### PR TITLE
For discussion only: Spike demonstrating lines returned given a folio URN

### DIFF
--- a/hmt_cite_atlas/library/shortcuts.py
+++ b/hmt_cite_atlas/library/shortcuts.py
@@ -1,6 +1,9 @@
 from .models import CITEDatum, CTSCatalog, CTSDatum
 
 
+CITATION_SCHEME_SCHOLION = "scholion"
+
+
 def get_lines_for_folio(folio_urn):
     """
     get_lines_for_folio("urn:cite2:hmt:msA.v1:12r")
@@ -17,9 +20,9 @@ def get_lines_for_folio(folio_urn):
         fields__contains={"urn:cite2:hmt:va_dse.v1.surface:": folio.urn}
     )
 
-    # @@@ what a hack, but is there another way to know the "work"
-    # vs commentaries?
-    catalog_obj = CTSCatalog.objects.get(work_title="Iliad")
+    catalog_obj = CTSCatalog.objects.exclude(
+        citation_scheme__contains=[CITATION_SCHEME_SCHOLION]
+    ).get()
     book_line_urn = catalog_obj.urn
 
     # @@@ might be a way we can do some db-level "icontains" against `urn:cite2:hmt:va_dse.v1.passage:`

--- a/hmt_cite_atlas/library/shortcuts.py
+++ b/hmt_cite_atlas/library/shortcuts.py
@@ -1,0 +1,29 @@
+from .models import CITEDatum, CTSCatalog, CTSDatum
+
+
+def get_lines_for_folio(folio_urn):
+    """
+    get_lines_for_folio("urn:cite2:hmt:msA.v1:12r")
+    """
+    try:
+        folio = CITEDatum.objects.get(urn=folio_urn)
+    except CITEDatum.DoesNotExist as e:
+        print(f'Could not resolve folio [urn="{folio_urn}""]')
+        raise e
+
+    # @@@ this will break in SQLite for the time being, but not in the future:
+    # https://code.djangoproject.com/ticket/12990
+    folio_cite_datum = CITEDatum.objects.filter(
+        fields__contains={"urn:cite2:hmt:va_dse.v1.surface:": folio.urn}
+    )
+
+    # @@@ what a hack, but is there another way to know the "work"
+    # vs commentaries?
+    catalog_obj = CTSCatalog.objects.get(work_title="Iliad")
+    book_line_urn = catalog_obj.urn
+
+    # @@@ might be a way we can do some db-level "icontains" against `urn:cite2:hmt:va_dse.v1.passage:`
+    line_cite_datum = folio_cite_datum.filter(fields__icontains=book_line_urn)
+    # @@@ might be a way we can use a subquery against the values in `urn:cite2:hmt:va_dse.v1.passage:`
+    line_urns = [l.fields["urn:cite2:hmt:va_dse.v1.passage:"] for l in line_cite_datum]
+    return CTSDatum.objects.filter(urn__in=line_urns)


### PR DESCRIPTION
@jhrr This is my crude but working way of resolving "Given a folio URN, what are the lines".

I've noted that there are some hacky bits in term of leveraging the ORM, but it works.  I've found with some other of my ATLAS implementations that there end up being certain types of things that get denormalized....I wonder if there would be a place where an ATLAS server that can ingest CEX files still ends up modeling the book/line model that @jtauber has championed.

E.g, we ingest all the CEX, but there is another ingestion script that will allow us to group lines by book or line by folio.

I could see further "annotation" (provided by some additional hooks within `graphene-django`) leveraging CEX for richer metadata as needed, but I'm just wondering if a `Version/Book/Line` simplification might make it a tad easier to do the types of queries we do on the other ATLAS servers.